### PR TITLE
Definir entradas com resistores de pull up/down

### DIFF
--- a/Brasilino.h
+++ b/Brasilino.h
@@ -78,8 +78,8 @@
 //------------------Funções de Configuração----------------
 #define saida(pino) pinMode(pino, OUTPUT)
 #define entrada(pino) pinMode(pino, INPUT)
-#define entradaAlta(pino) { pinMode(pino, INPUT); DigitalWrite(pino,HIGH) }
-#define entradaBaixa(pino) { pinMode(pino, INPUT); DigitalWrite(pino,LOW) }
+#define entradaAlta(pino) {pinMode(pino,INPUT);DigitalWrite(pino,HIGH)}
+#define entradaBaixa(pino) {pinMode(pino,INPUT);DigitalWrite(pino,LOW)}
 #define definirPino(pino, tipo) pinMode(pino, tipo)
 
 //------------------Funções de Serial----------------------

--- a/Brasilino.h
+++ b/Brasilino.h
@@ -78,6 +78,8 @@
 //------------------Funções de Configuração----------------
 #define saida(pino) pinMode(pino, OUTPUT)
 #define entrada(pino) pinMode(pino, INPUT)
+#define entradaAlta(pino) { pinMode(pino, INPUT); DigitalWrite(pino,HIGH) }
+#define entradaBaixa(pino) { pinMode(pino, INPUT); DigitalWrite(pino,LOW) }
 #define definirPino(pino, tipo) pinMode(pino, tipo)
 
 //------------------Funções de Serial----------------------

--- a/Brasilino.h
+++ b/Brasilino.h
@@ -78,8 +78,7 @@
 //------------------Funções de Configuração----------------
 #define saida(pino) pinMode(pino, OUTPUT)
 #define entrada(pino) pinMode(pino, INPUT)
-#define entradaAlta(pino) {pinMode(pino,INPUT);DigitalWrite(pino,HIGH)}
-#define entradaBaixa(pino) {pinMode(pino,INPUT);DigitalWrite(pino,LOW)}
+#define entradaAlta(pino) pinMode(pino,INPUT_PULLUP)
 #define definirPino(pino, tipo) pinMode(pino, tipo)
 
 //------------------Funções de Serial----------------------


### PR DESCRIPTION
Arduino possui resistores internos de Pull Up/Down, não necessitando de circuito externo para as entradas, contudo eles precisam ser ativados no setup, deixei a definição entrada comum pois o usuário pode querer controlar os resistores, fazendo um chaveador de habilita/desabilita.
PR foi feito no develop porque a feature precisa de testes.