### PR TITLE
fix: Uso da função iniciarSerial()

### DIFF
--- a/src/Brasilino.cpp
+++ b/src/Brasilino.cpp
@@ -1,6 +1,14 @@
 #include "Brasilino.h"
 #include <math.h>
 
+void iniciarSerial(void) {
+  Serial.begin(9600);
+}
+
+void iniciarSerial(int baud) {
+  Serial.begin(baud);
+}
+
 dobro temperatura(inteiro valorAnalogico) {
     dobro Temp;
     Temp = log(10000.0*((1024.0/valorAnalogico-1)));

--- a/src/Brasilino.h
+++ b/src/Brasilino.h
@@ -84,8 +84,8 @@
 #define definirPino(pino, tipo) pinMode(pino, tipo)
 
 //------------------Funções de Serial----------------------
-#define iniciarSerial() Serial.begin(9600)
-#define iniciarSerialBaud(baud) Serial.begin(baud)
+void iniciarSerial(void);
+void iniciarSerial(int baud);
 
 #define lerSerial() Serial.read()
 #define escreverSerialn(texto) Serial.println(texto)


### PR DESCRIPTION
Agora, no lugar do `#define USAR_BAUD` ou de duas funções para
definir o baud rate automaticamente ou manualmente, está definido
uma função sobrecarregada que pode ou não receber parâmetros.

Resolves: #5