### PR TITLE
Corrigindo Badge Open Source Love

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
+[![Open Source Love](https://badges.frapsoft.com/os/v2/open-source.png?v=103)](https://github.com/ellerbrock/open-source-badges/)
 [![License: GPL3](https://img.shields.io/badge/License-GPL3-green.svg)](https://opensource.org/licenses/GPL-3.0)
 
 # Brasilino


### PR DESCRIPTION
O badge em .svg é transparente, e não fica visível com o fundo branco do GitHub.
Ele foi substituído pela versão em .png que não tem transparência.