### PR TITLE
Adicionado comparadores

### DIFF
--- a/src/Brasilino.h
+++ b/src/Brasilino.h
@@ -116,8 +116,6 @@ class Ultrassom
 	long tempo_limite;
 	long duracao;
 };
-#endif
-// Não apagar antes disto.
 
 //------------------Comparadores----------------------
 #define igual ==
@@ -127,3 +125,6 @@ class Ultrassom
 #define menor_igual <=
 #define logico_e &&
 #define logico_ou ||
+
+#endif
+// Não apagar antes disto.

--- a/src/Brasilino.h
+++ b/src/Brasilino.h
@@ -118,3 +118,12 @@ class Ultrassom
 };
 #endif
 // Não apagar antes disto.
+
+//------------------Comparadores----------------------
+#define igual ==
+#define maior >
+#define maior_igual >=
+#define menor <
+#define menor_igual <=
+#define logico_e &&
+#define logico_ou ||


### PR DESCRIPTION
Mesmo não sendo necessariamente uma tradução, acredito que usar "maior", "igual", etc. no lugar de ">", "=", por exemplo, pode ser didático