### PR TITLE
Adicionar ENTRADA_ALTA

### DIFF
--- a/src/Brasilino.h
+++ b/src/Brasilino.h
@@ -21,6 +21,7 @@
 #endif
 
 //------------------Argumentos Lógicos---------------------
+#define ENTRADA_ALTA INPUT_PULLUP
 #define ENTRADA INPUT
 #define SAIDA OUTPUT
 #define ALTO HIGH


### PR DESCRIPTION
reparei que os tipos de entrada faltou um alias para `INPUT_PULLUP`, podendo se chamar `ENTRADA_ALTA`.