### PR TITLE
Arduino Compile Sketch

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,78 @@
+name: Arduino Compile
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
+  workflow_dispatch:
+
+jobs:
+  # This is the name of the job - can be whatever.
+  test-matrix:
+
+    # Here we tell GitHub that the jobs must be determined
+    # dynamically depending on a matrix configuration.
+    strategy:
+      matrix:
+        # The matrix will produce one job for each configuration
+        # parameter of type `arduino-platform`, in this case a
+        # total of 2.
+        arduino-platform: ["arduino:avr"]
+        # This is usually optional but we need to statically define the
+        # FQBN of the boards we want to test for each platform. In the
+        # future the CLI might automatically detect and download the core
+        # needed to compile against a certain FQBN, at that point the
+        # following `include` section will be useless.
+        include:
+          # This works like this: when the platformn is "arduino:samd", the
+          # variable `fqbn` is set to "arduino:samd:nano_33_iot".
+          - arduino-platform: "arduino:avr"
+            fqbn: "arduino:avr:uno"
+
+    # This is the platform GitHub will use to run our workflow, we
+    # pick Windows for no particular reason.
+    runs-on: ubuntu-latest
+
+    # This is the list of steps this job will run.
+    steps:
+      # First of all, we clone the repo using the `checkout` action.
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Instalar Compactador Zip
+        uses: montudor/action-zip@v0.1.1
+
+      - name: Compacta Brasilino.zip
+        run: zip -qq -r src.zip src
+        working-directory: ${{ github.workspace }}
+
+      # We use the `arduino/setup-arduino-cli` action to install and
+      # configure the Arduino CLI on the system.
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v1.1.1
+
+      # We then install the platform, which one will be determined
+      # dynamically by the build matrix.
+      - name: Instalar Plataforma Arduino
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install ${{ matrix.arduino-platform }}
+
+      # Habilitar a instalação não segura da biblioteca Brasilino local
+      # é necessário criar um config file para armazenar o valor da flag
+      - name: Habilitar instalação não segura
+        run: |
+          arduino-cli config init 
+          arduino-cli config set library.enable_unsafe_install true
+      
+      # Instalação da Biblioteca Brasilino Local
+      - name: Instalação Brasilino
+        run: |
+          arduino-cli lib install --zip-path ${{ github.workspace }}/src.zip
+    
+      # Finally, we compile the sketch, using the FQBN that was set
+      # in the build matrix.
+      - name: Compile Sketch
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Basicos/Piscar

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -9,19 +9,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  # This is the name of the job - can be whatever.
-  test-placas:
+  # Nome do trabalho a ser realizado
+  compile:
 
-    # Here we tell GitHub that the jobs must be determined
-    # dynamically depending on a matrix configuration.
     strategy:
+      # Estratégia em Matrix, pois vamos trabalhar com diversos tipos de placa
       matrix:
 
+        #Aqui a escolha de placas se dá pelos nomes das placas, não há necessidade
+        #de um nome específico, funciona apenas como identificação
         boards: [arduino-uno, arduino-mega, arduino-leonardo, arduino-gemma]
 
         include:
-          # This works like this: when the platformn is "arduino:samd", the
-          # variable `fqbn` is set to "arduino:samd:nano_33_iot".
+          # Aqui iremos setar algumas informações necessárias para cada placa
+          #
+          # Variável arduino-platform:
+          # Neste caso se refere diretamente a variável da plataforma em que a placa é trabalhada
+          # As placas padrões da Plataforma Arduino são conhecidas como arduino:avr devido sua 
+          # arquitetura de microcontroladores AVR
+          #
+          # Variável fqbn:
+          # Se refere diretamente a escolha da placa ao qual você deseja realizar um trabalho
           - boards: arduino-uno
             arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:uno"
@@ -38,30 +46,32 @@ jobs:
             arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:gemma"
             
-    # This is the platform GitHub will use to run our workflow, we
-    # pick Windows for no particular reason.
+    # Plataforma em que iremos rodar o workflow
     runs-on: ubuntu-latest
 
-    # This is the list of steps this job will run.
+    # Lista de trabalhos a serem realizados
     steps:
-      # First of all, we clone the repo using the `checkout` action.
+      # Vamos utilizar a Action 'checkout' para trabalhar com os clones do repositório
+      # requisito da action setup-arduino-cli
       - name: Checkout
         uses: actions/checkout@master
 
-      - name: Instalar Compactador Zip
+      # É necessário Compactar a pasta src (fonte da biblioteca)
+      # é uma necessidade do arduino-cli para instalar e usar a biblioteca Brasilino.h.
+      - name: Instalação Compactador Zip
         uses: montudor/action-zip@v0.1.1
 
       - name: Compacta Brasilino.zip
         run: zip -qq -r src.zip src
         working-directory: ${{ github.workspace }}
 
-      # We use the `arduino/setup-arduino-cli` action to install and
-      # configure the Arduino CLI on the system.
-      - name: Setup Arduino CLI
+      # Nós usamos a Action 'setup-arduino-cli' para instalar e configurar a 'arduino-cli'
+      # a ferramenta/Action que irá realizar a compilação dos sketches para as placas 
+      - name: Instalação Arduino CLI
         uses: arduino/setup-arduino-cli@v1.1.1
 
-      # We then install the platform, which one will be determined
-      # dynamically by the build matrix.
+      # Nós fazemos a instalação da plataforma que irá dinâmicamente ser construído 
+      # pela estratégia da matrix
       - name: Instalar Plataforma Arduino
         run: |
           arduino-cli core update-index
@@ -80,6 +90,7 @@ jobs:
           arduino-cli lib install --zip-path ${{ github.workspace }}/src.zip
     
       # Finally, we compile the sketch, using the FQBN that was set
-      # in the build matrix.
+      # Nós finalmente, compilamos os sketch, usando a flag --fqbn que é setada
+      # na construção da matrix
       - name: Compile Sketch
         run: arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Basicos/Piscar

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -10,27 +10,34 @@ on:
 
 jobs:
   # This is the name of the job - can be whatever.
-  test-matrix:
+  test-placas:
 
     # Here we tell GitHub that the jobs must be determined
     # dynamically depending on a matrix configuration.
     strategy:
       matrix:
-        # The matrix will produce one job for each configuration
-        # parameter of type `arduino-platform`, in this case a
-        # total of 2.
-        arduino-platform: ["arduino:avr"]
-        # This is usually optional but we need to statically define the
-        # FQBN of the boards we want to test for each platform. In the
-        # future the CLI might automatically detect and download the core
-        # needed to compile against a certain FQBN, at that point the
-        # following `include` section will be useless.
+
+        boards: [arduino-uno, arduino-mega, arduino-leonardo, arduino-gemma]
+
         include:
           # This works like this: when the platformn is "arduino:samd", the
           # variable `fqbn` is set to "arduino:samd:nano_33_iot".
-          - arduino-platform: "arduino:avr"
+          - boards: arduino-uno
+            arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:uno"
 
+          - boards: arduino-mega
+            arduino-platform: "arduino:avr"
+            fqbn: "arduino:avr:mega"
+
+          - boards: arduino-leonardo
+            arduino-platform: "arduino:avr"
+            fqbn: "arduino:avr:leonardo"
+
+          - boards: arduino-gemma
+            arduino-platform: "arduino:avr"
+            fqbn: "arduino:avr:gemma"
+            
     # This is the platform GitHub will use to run our workflow, we
     # pick Windows for no particular reason.
     runs-on: ubuntu-latest

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -20,7 +20,7 @@ jobs:
 
         #Aqui a escolha de placas se dá pelos nomes das placas, não há necessidade
         #de um nome específico, funciona apenas como identificação
-        boards: [arduino-uno, arduino-mega, arduino-leonardo, arduino-gemma]
+        boards: [arduino-uno, arduino-mega, arduino-leonardo, arduino-gemma, micronucleus-franzininho]
 
         include:
           # Aqui iremos setar algumas informações necessárias para cada placa
@@ -47,6 +47,12 @@ jobs:
           - boards: arduino-gemma
             arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:gemma"
+          
+          - boards: micronucleus-franzininho
+            arduino-platform: "digistump:avr"
+            flag-additional-urls: "--additional-urls http://digistump.com/package_digistump_index.json"
+            fqbn: "digistump:avr:digispark-tiny"
+            flag-programmer: "--programmer micronucleus"
             
     # Plataforma em que iremos rodar o workflow
     runs-on: ubuntu-latest
@@ -76,8 +82,9 @@ jobs:
       # pela estratégia da matrix
       - name: Instalar Plataforma Arduino
         run: |
+          arduino-cli core download ${{ matrix.arduino-platform }} ${{ matrix.flag-additional-urls }}
           arduino-cli core update-index
-          arduino-cli core install ${{ matrix.arduino-platform }}
+          arduino-cli core install ${{ matrix.arduino-platform }} ${{ matrix.flag-additional-urls }}
 
       # Habilitar a instalação não segura da biblioteca Brasilino local
       # é necessário criar um config file para armazenar o valor da flag
@@ -96,11 +103,11 @@ jobs:
       # na construção da matrix
       - name: Compile Sketch
         run: |
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Atuadores/Motor
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Basicos/Piscar
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Basicos/analogicoSerial
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Intermediario/quarentaedois
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Sensores/Botao
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Sensores/Luminosidade
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Sensores/Temperatura
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Sensores/Ultrassom-HC-SR04
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Atuadores/Motor
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/Piscar
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/analogicoSerial
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Intermediario/quarentaedois
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Botao
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Luminosidade
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Temperatura
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Ultrassom-HC-SR04

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -103,7 +103,6 @@ jobs:
       # na construção da matrix
       - name: Compile Sketch
         run: |
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Atuadores/Motor
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/Piscar
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/analogicoSerial
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Intermediario/quarentaedois
@@ -111,3 +110,4 @@ jobs:
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Luminosidade
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Temperatura
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Ultrassom-HC-SR04
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Atuadores/Motor

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -95,4 +95,12 @@ jobs:
       # Nós finalmente, compilamos os sketch, usando a flag --fqbn que é setada
       # na construção da matrix
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Basicos/Piscar
+        run: |
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Atuadores/Motor
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Basicos/Piscar
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Basicos/analogicoSerial
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Intermediario/quarentaedois
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Sensores/Botao
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Sensores/Luminosidade
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Sensores/Temperatura
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ./examples/Sensores/Ultrassom-HC-SR04

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,6 +13,8 @@ jobs:
   compile:
 
     strategy:
+      # Desabilita fail-fast e garante que todas as matrix sejam testadas
+      fail-fast: false
       # Estratégia em Matrix, pois vamos trabalhar com diversos tipos de placa
       matrix:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: GPL3](https://img.shields.io/badge/License-GPL3-green.svg)](https://opensource.org/licenses/GPL-3.0)
 [![Arduino Lint](https://github.com/OtacilioN/Brasilino/workflows/Arduino%20Lint/badge.svg)](https://github.com/OtacilioN/Brasilino/actions?workflow=Arduino+Lint)
+[![Arduino Compile](https://github.com/OtacilioN/Brasilino/actions/workflows/compile.yml/badge.svg)](https://github.com/OtacilioN/Brasilino/actions/workflows/compile.yml)
 
 _Uma **biblioteca** que permite programar em linguagem **Arduino** utilizando comandos facilitados em **PT-BR**._
 


### PR DESCRIPTION
## Sumário

Esta Pull Request visa implantar o Arduino Compile Sketch como CI, por meio da ferramenta GitHub Action, como em #64. 

O Arduino Compile Sketch é uma ferramenta que se baseia nas ferramentas da Arduino-CLI, para compilação e ~envio, quem sabe futuramente~. Com essa Action será possível compilar os códigos de exemplos, para verificar e assegurar que a compilação em determinadas placas está ocorrendo com sucesso, facilitando o processo de testagem, visto que, havia certas dificuldades (#26) em assegurar que push e pull request funcionavam para todas as placas que o Brasilino realiza suporte.

## Outras Informações

### Checklist
- [x] Implantar o Arduino Compile Sketch
- [x] Escolher as placas que serão compiladas
- [x] Implementar as placas em `test-placas`
- [x] Definir quais serão os códigos básicos a serem compilados
  - `controleGradual` não inserido por estar descontinuado
  - `ASCII` não inserido por estar descontinuado
- [x] Estilizar o workflow `compile.yml` ~deixar bonito~
- [x] (Opcional) Inserir Badge do Arduino Compile Sketch

### Testes

Foram realizados testes em minha fork, disponível em [SteffanoP/Brasilino](https://github.com/SteffanoP/Brasilino).

Nas Actions deste projeto é possível visualizar [diversos testes](https://github.com/OtacilioN/Brasilino/actions/workflows/compile.yml).

Como também nas Actions de minha fork para ver [**todos os testes**](https://github.com/SteffanoP/Brasilino/actions/workflows/compile.yml).

### Sobre o Franzininho

Como requerido por @ErickSimoes, seria interessante alguma placa compatível com ATtiny85 (do Franzininho). A priori, foi estabelecido a placa **Arduino Gemma** e também a placa da Digispark-tiny com Programador micronucleus.

## Descrição das mudanças

Cria o Action Workflow: `compile.yml`, com função de compilar os códigos de exemplos em Brasilino/examples. Atua sempre que houver Push e Pull Requests na/para branch master ~odeio esse nome, prefiro main~.

Há apenas um job a ser realizado, que se trata do `Arduino Compile / test-placas`.

Em `test-placas` a estratégia adotada é de _matrix_, que envolve as `boards` (placas) a serem testadas:

- arduino-uno
- arduino-mega
- arduino-leonardo
- arduino-gemma
- ATiny-micronucleus

O ambiente de teste é o ubuntu, devido a compatibilidade do compactador Zip.

Os passos seguem a seguinte ordem:

### Checkout

Utilizado para estabelecer e gerenciar o repositório Git

### Instalar Compactador Zip

É necessário Compactar a pasta `src` (fonte da biblioteca), visto que, é uma necessidade do arduino-cli para instalar a biblioteca `Brasilino.h`.

### Setup Arduino CLI

É de suma importância nesta Pull Request, visto que, será a ferramenta que irá realizar a compilação dos sketches para as placas citadas anteriormente

### Instalar Plataforma Arduino

Realiza a instalação da Plataforma de placas, ao qual, se refere diretamente ao conjunto de placas da plataforma e seus requisitos (trata-se do compilador, na Arduino IDE chamamos de Programador).

### Habilitar instalação não segura

É um requisito do tópico [Instalação Brasilino](#Instalação-Brasilino), pois o método para instalar a biblioteca se baseia em pegar o formato .zip da biblioteca local, todavia, essa não é uma instalação segura, pois, conforme a [Arduino Team diz](https://arduino.github.io/arduino-cli/latest/configuration/#configuration-keys), este processo não passa pelo Processo de Gerenciamento de Bibliotecas. MAS, neste caso, não é necessário tal precaução, visto que, você está tratando o código fonte da própria biblioteca; logo, a precaução não é necessária neste caso.

### Instalação Brasilino

Realiza a Instalação da Biblioteca local (on push ou on PR), por meio do método `arduino-cli lib install --zip-path` que obtém a `Brasilino.h` em formato `.zip`, visto em [Instalar Compactador Zip](#Instalar-Compactador-Zip).

### Compile Sketch

Faz o Compile de Sketch, neste caso específico, realiza o Compile apenas do Programa `Piscar.ino`.

## Benefícios

Possibilita realizar uma triagem mais detalhada nas compilações de códigos para diversas plataformas Arduino (ex.: arduinoavr, arduinoOTA, esp32, esp8266 e etc.).

## Possíveis desvantagens

A implementação do modo de compilação para os diversos exemplos acontece de maneira contínua para cada _job_, ou seja, em cada _job_ que é executado é realizado o _compile_ de todos os exemplos, e se um exemplo apresentar um erro não é compilado o restante dos códigos. O ideal seria colocar cada comando `arduino-cli compile` em matrix; porém devido as limitações do meu conhecimento, não consegui fazer de uma forma que cada compile dos `./exemplos` se tornasse independente.

Também há a necessidade de adicionar um _script_ para realizar o _compile_ de forma automática, atualmente é necessário alterar **manualmente** o destino de compile no `./.github/workflows/compile.yml` sempre que for adicionado um exemplo.

## Problemas Relacionados

Esta PR facilita o processo de testagem e triagem da PR #26

Resolves #66
