### PR TITLE
fix: verificação de Arduino AVR Digispark

### DIFF
--- a/src/Brasilino.cpp
+++ b/src/Brasilino.cpp
@@ -15,6 +15,7 @@
 #include <math.h>
 
 #if defined(ARDUINO_AVR_GEMMA)
+#elif defined(ARDUINO_AVR_DIGISPARK)
 #else
 void iniciarSerial(void)
 {

--- a/src/Brasilino.h
+++ b/src/Brasilino.h
@@ -93,6 +93,7 @@
 
 //------------------Funções de Serial----------------------
 #if defined(ARDUINO_AVR_GEMMA)
+#elif defined(ARDUINO_AVR_DIGISPARK)
 #else
 void iniciarSerial(void);
 void iniciarSerial(int baud);


### PR DESCRIPTION
*Faz uma verificação, além do Arduino Gemma, estabelece para placas Arduino_AVR_Digispark que não possuem interface Serial

*Corresponde ao Fix (OtacilioN/Brasilino#28), com foco na placa **Franzininho** com programmer **micronucleus** de arquitetura **AVR_Digispark**

_Compilado `Piscar.ino` para todas as placas `Arduino_AVR_Digispark`_