### PR TITLE
docs: keywords de funções `imprimirSerialEspecial` e `imprimirSerialnEspecial`

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,8 +9,10 @@
 Brasilino	KEYWORD1
 iniciarSerial	KEYWORD1
 lerSerial	KEYWORD1
-escreverSerialn	KEYWORD1
 escreverSerial	KEYWORD1
+escreverSerialn	KEYWORD1
+escreverSerialEspecial 	KEYWORD1
+escreverSerialnEspecial	KEYWORD1
 Ultrassom	KEYWORD1
 Motor	KEYWORD1
 


### PR DESCRIPTION
## Sumário
Complementa a PR #70, em inserir em `keywords.txt`, os novos comandos como parte da documentação e gerenciamento da biblioteca `Brasilino.h`

## Resultado Esperado

![Demonstração da keyword na IDE do Arduino](https://user-images.githubusercontent.com/26782009/112855909-aa786880-9085-11eb-8e9d-45d2ae3b8487.png)

Resultado pode ser observado pela ênfase em laranja da Arduino IDE (linhas `55`,`59` e `63`; exemplo `ASCII.ino`) e também de serve de referência para editores com recursos Intellisense ou semelhantes.