### PR TITLE
Estabelece restrições para trabalhos da Arduino Compile para placas sem interface Serial nativa

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -101,13 +101,39 @@ jobs:
       # Finally, we compile the sketch, using the FQBN that was set
       # Nós finalmente, compilamos os sketch, usando a flag --fqbn que é setada
       # na construção da matrix
-      - name: Compile Sketch
+      #
+      # Teste de ./examples/Basicos
+      - name: Compile Sketch Piscar.ino
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/Piscar
+      
+      - name: Compile Sketch analogicoSerial.ino
+        run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/analogicoSerial
+
+      # Teste de ./examples/Intermediario
+      - name: Compile Sketch quarentaedois.ino
+        run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Intermediario/quarentaedois
+      
+      # Teste de ./examples/Sensores
+      - name: Compile Sketch Botao.ino
+        run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Botao
+      
+      - name: Compile Sketch Luminosidade.ino
+        run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Luminosidade
+
+      - name: Compile Sketch Temperatura.ino
+        run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Temperatura
+
+      - name: Compile Sketch Ultrassom-HC-SR04
+        run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Ultrassom-HC-SR04
+
+      # Teste de ./examples/Atuadores
+      - name: Compile Sketch Motor.ino
+        run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Atuadores/Motor

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -32,6 +32,12 @@ jobs:
           #
           # Variável fqbn:
           # Se refere diretamente a escolha da placa ao qual você deseja realizar um trabalho
+          # 
+          # Variável serial-enabled:
+          # Se refere as placas que possuem comunicação serial por meio de interface USB padrão
+          # do Arduino, que é a mesma serial do Monitor Serial. Essa variável é necessária, pois
+          # há placas (arduino-gemma e micronucleus-franzininho) que trabalham com processador que 
+          # não suporta interface serial dos exemplos
           - boards: arduino-uno
             arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:uno"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -160,6 +160,5 @@ jobs:
 
       # Teste de ./examples/Atuadores
       - name: Compile Sketch Motor.ino
-        if: matrix.serial-enabled == true
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Atuadores/Motor

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -88,6 +88,8 @@ jobs:
       # a ferramenta/Action que irá realizar a compilação dos sketches para as placas 
       - name: Instalação Arduino CLI
         uses: arduino/setup-arduino-cli@v1.1.1
+        with:
+          version: "0.17.0"
 
       # Nós fazemos a instalação da plataforma que irá dinâmicamente ser construído 
       # pela estratégia da matrix

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -113,7 +113,7 @@ jobs:
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/Piscar
       
       - name: Compile Sketch analogicoSerial.ino
-        if: matrix.serial-enabled == 'true'
+        if: matrix.serial-enabled == true
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/analogicoSerial
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -123,7 +123,16 @@ jobs:
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/analogicoSerial
 
+      - name: Compile Sketch controleGradual.ino
+        run: |
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/controleGradual
+
       # Teste de ./examples/Intermediario
+      - name: Compile Sketch ASCII.ino
+        if: matrix.serial-enabled == true
+        run: |
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Intermediario/ASCII
+
       - name: Compile Sketch quarentaedois.ino
         if: matrix.serial-enabled == true
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -119,7 +119,7 @@ jobs:
 
       # Teste de ./examples/Intermediario
       - name: Compile Sketch quarentaedois.ino
-        if: matrix.serial-enabled == 'true'
+        if: matrix.serial-enabled == true
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Intermediario/quarentaedois
       
@@ -129,22 +129,22 @@ jobs:
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Botao
       
       - name: Compile Sketch Luminosidade.ino
-        if: matrix.serial-enabled == 'true'
+        if: matrix.serial-enabled == true
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Luminosidade
 
       - name: Compile Sketch Temperatura.ino
-        if: matrix.serial-enabled == 'true'
+        if: matrix.serial-enabled == true
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Temperatura
 
       - name: Compile Sketch Ultrassom-HC-SR04
-        if: matrix.serial-enabled == 'true'
+        if: matrix.serial-enabled == true
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Ultrassom-HC-SR04
 
       # Teste de ./examples/Atuadores
       - name: Compile Sketch Motor.ino
-        if: matrix.serial-enabled == 'true'
+        if: matrix.serial-enabled == true
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Atuadores/Motor

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -35,24 +35,29 @@ jobs:
           - boards: arduino-uno
             arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:uno"
+            serial-enabled: true
 
           - boards: arduino-mega
             arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:mega"
+            serial-enabled: true
 
           - boards: arduino-leonardo
             arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:leonardo"
+            serial-enabled: true
 
           - boards: arduino-gemma
             arduino-platform: "arduino:avr"
             fqbn: "arduino:avr:gemma"
+            serial-enabled: false
           
           - boards: micronucleus-franzininho
             arduino-platform: "digistump:avr"
             flag-additional-urls: "--additional-urls http://digistump.com/package_digistump_index.json"
             fqbn: "digistump:avr:digispark-tiny"
             flag-programmer: "--programmer micronucleus"
+            serial-enabled: false
             
     # Plataforma em que iremos rodar o workflow
     runs-on: ubuntu-latest
@@ -108,11 +113,13 @@ jobs:
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/Piscar
       
       - name: Compile Sketch analogicoSerial.ino
+        if: matrix.serial-enabled == 'true'
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Basicos/analogicoSerial
 
       # Teste de ./examples/Intermediario
       - name: Compile Sketch quarentaedois.ino
+        if: matrix.serial-enabled == 'true'
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Intermediario/quarentaedois
       
@@ -122,18 +129,22 @@ jobs:
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Botao
       
       - name: Compile Sketch Luminosidade.ino
+        if: matrix.serial-enabled == 'true'
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Luminosidade
 
       - name: Compile Sketch Temperatura.ino
+        if: matrix.serial-enabled == 'true'
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Temperatura
 
       - name: Compile Sketch Ultrassom-HC-SR04
+        if: matrix.serial-enabled == 'true'
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Sensores/Ultrassom-HC-SR04
 
       # Teste de ./examples/Atuadores
       - name: Compile Sketch Motor.ino
+        if: matrix.serial-enabled == 'true'
         run: |
           arduino-cli compile --fqbn ${{ matrix.fqbn }} ${{ matrix.flag-programmer }} ./examples/Atuadores/Motor


### PR DESCRIPTION
## Sumário

Esta Pull Request visa estabelecer restrições de trabalhos (_jobs_) para placas sem interface Serial nativa (Ex.: Arduino Gemma e Franzininho). 

## Outras Informações

Além disso, insere os códigos `controleGradual.ino` e `ASCII.ino` para compile, por meio da Action [Arduino Compile](https://github.com/OtacilioN/Brasilino/actions/workflows/compile.yml).

EDIT (03/04/2021):

Limita a versão da arduino-cli para a versão 0.17.0, pois versões superiores apresentaram mudanças com quebra.

### Testes

Foram realizados testes em minha fork, disponível em [SteffanoP/Brasilino](https://github.com/SteffanoP/Brasilino).

Nas Actions deste projeto é possível visualizar [alguns testes](https://github.com/OtacilioN/Brasilino/actions/workflows/compile.yml).

Como também nas Actions de minha fork para ver [**todos os testes**](https://github.com/SteffanoP/Brasilino/actions/workflows/compile.yml).

## Descrição das mudanças

- Individualiza as etapas (_steps_) para cada Sketch (e353950)
- Restringe o Compile dos códigos para placas com interface serial nativa (6a6c762 e bda3c7a):
  - `analogicoSerial.ino`
  - `quarentaedois.ino`
  - `Luminosidade.ino`
  - `Temperatura.ino`
  - `Ultrassom-HC-SR04.ino`
- Volta a testar os Sketches (bda3c7a): 
  - `controleGradual.ino` 
  - `ASCII.ino` 

## Benefícios

Estabelece compatibilidade da Integração Contínua Arduino Compile com placas de interface serial não nativa, ou seja, as placas `arduino-gemma` e `micronucleus-franzininho` irão ser restringidos em etapas (_steps_) do trabalho (_job_),  resolvendo os problemas constatados em #68. A restrição do compile se vale apenas para exemplos em que a interface Serial não é nativa (exemplos com comandos como `iniciarSerial()` e `escreverSerial()` passam a não ser válidos de teste para essas placas).

## Possíveis desvantagens

Ainda há a necessidade de adicionar um _script_ para realizar o _compile_ de forma automática, atualmente é necessário alterar **manualmente** o destino de compile no `./.github/workflows/compile.yml` sempre que for adicionado um exemplo.

## Problemas Relacionados

Resolves #68 
