### PR TITLE
Colocando a constante LED_INTERNO referente a LED_BUILTIN

### DIFF
--- a/src/Brasilino.h
+++ b/src/Brasilino.h
@@ -19,6 +19,8 @@
 #else
 #include "WProgram.h"
 #endif
+// ------------------Constantes---------------------
+#define LED_INTERNO LED_BUILTIN // contribuição de @EduardaOL
 
 //------------------Argumentos Lógicos---------------------
 #define ENTRADA_ALTA INPUT_PULLUP


### PR DESCRIPTION
Foi adicionada a constante LED_Interno como equivalente em português de LED_BUILTIN.
Assim, o código continua compatível com diferentes placas e fica mais amigável para quem prefere termos em PT-BR.
resolve #86 