### PR TITLE
Corrige os exemplos Luminosidade e Ultrassom

### DIFF
--- a/examples/Sensores/Luminosidade/Luminosidade.ino
+++ b/examples/Sensores/Luminosidade/Luminosidade.ino
@@ -1,5 +1,5 @@
 /*
-    Temperatura   
+    Luminosidade
     Lê o valor obtido pelo sensor LDR, e mostra o resultado em °C no monitor serial.
     
     Utilize um LDR de 10k, alimentado com +5v e com um resistor de 10k entre o pino A1 e o gnd. 

--- a/examples/Sensores/Ultrassom/Ultrassom.ino
+++ b/examples/Sensores/Ultrassom/Ultrassom.ino
@@ -17,7 +17,7 @@
 #include <Brasilino.h>
 
 Ultrassom ultrassom(8, 9);
-int distancia;
+inteiro distancia;
 
 funcao configurar() {
   // Inicializa a comunicação serial com a placa


### PR DESCRIPTION
Agora, no exemplo `Sensores\Ultrassom`, a variável criada para receber a distância está definida como `inteiro` e, no exemplo `Sensores\Luminosidade`, o comentário do código está escrito `Luminosidade`.

resolve #95 
resolve #97 