### PR TITLE
Adiciona exemplo de uso de sensor infravermelho

### DIFF
--- a/examples/0.4 Sensores/Infravermelho/Infravermelho.ino
+++ b/examples/0.4 Sensores/Infravermelho/Infravermelho.ino
@@ -1,10 +1,11 @@
 /*
     Infravermelho
     Lê o valor analógico obtido por um sensor de reflexão infravermelho (como o TCRT5000), 
-    mostra o resultado no monitor serial e identifica se há um obstáculo ou linha preta.
+    mostra o resultado no monitor serial e classifica a quantidade de luz refletida.
     
-    Conecte o pino de sinal analógico (AO) do sensor ao pino A0 do Arduino.
-    Alimente o sensor com +5V e GND.
+    Obs.: Alguns módulos invertem a leitura; se necessário, ajuste o limite e/ou inverta a comparação.
+    
+    Conecte o pino de sinal analógico (AO) do sensor ao pino A0 do Arduino. Alimente o sensor com +5V e GND.
 */
 
 #include <Brasilino.h>

--- a/examples/0.4 Sensores/Infravermelho/Infravermelho.ino
+++ b/examples/0.4 Sensores/Infravermelho/Infravermelho.ino
@@ -1,0 +1,42 @@
+/*
+    Infravermelho
+    Lê o valor analógico obtido por um sensor de reflexão infravermelho (como o TCRT5000), 
+    mostra o resultado no monitor serial e identifica se há um obstáculo ou linha preta.
+    
+    Conecte o pino de sinal analógico (AO) do sensor ao pino A0 do Arduino.
+    Alimente o sensor com +5V e GND.
+*/
+
+#include <Brasilino.h>
+
+// Definição do pino analógico (A0)
+constante inteiro sensorIV = A0; 
+
+// Valor de corte para identificar proximidade/cor (ajuste conforme seu teste)
+constante inteiro limiteReflexao = 500; 
+
+inteiro leituraAtual = 0;
+
+funcao configurar() {
+    // Inicializa a comunicação serial com a placa
+    iniciarSerial(); 
+}
+
+funcao repetir() {
+    // Realiza a leitura analógica do sensor IV no pino A0
+    leituraAtual = lerAnalogico(sensorIV);
+
+    // Analisa o valor lido e emite uma opinião com base no limite definido
+    // (Geralmente, sensores IV mudam drasticamente o valor entre superfícies claras e escuras)
+    se (leituraAtual < limiteReflexao) {
+        escreverSerial("Objeto Proximo e/ou Superficie Clara: ");
+    } senao {
+        escreverSerial("Objeto Afastado e/ou Superficie Escura: ");
+    }
+
+    // Imprime no Monitor Serial o valor numérico atual
+    escreverSerialn(leituraAtual);
+
+    // Espera 200 Milissegundos antes da próxima leitura
+    esperarMili(200);
+}

--- a/examples/0.4 Sensores/Infravermelho/Infravermelho.ino
+++ b/examples/0.4 Sensores/Infravermelho/Infravermelho.ino
@@ -30,9 +30,9 @@ funcao repetir() {
     // Analisa o valor lido e emite uma opinião com base no limite definido
     // (Geralmente, sensores IV mudam drasticamente o valor entre superfícies claras e escuras)
     se (leituraAtual < limiteReflexao) {
-        escreverSerial("Objeto Proximo e/ou Superficie Clara: ");
+        escreverSerial("Muita luz refletida: ");
     } senao {
-        escreverSerial("Objeto Afastado e/ou Superficie Escura: ");
+        escreverSerial("Pouca luz refletida: ");
     }
 
     // Imprime no Monitor Serial o valor numérico atual


### PR DESCRIPTION
Adiciona exemplo de uso do sensor infravermelho em examples/0.4 Sensores/Infravermelho/Infravermelho.ino. O código realiza leitura analógica, exibe o valor no monitor serial e identifica superfícies  próximas e/ou  claras ou distantes e/ou escuras com base em um limite de reflexão ajustável.